### PR TITLE
Additional script that allows me to specify the feed URL manually

### DIFF
--- a/load-custom.js
+++ b/load-custom.js
@@ -83,6 +83,4 @@ window.subToMe = function(url) {
       var _gaq = window._gaq || [];
       _gaq.push(['_trackEvent', 'subtome', 'follow', event.data.subscription.app.name]);
     });
-
-  })();
-
+}


### PR DESCRIPTION
I'll first point you at a quick email between @julien51 and myself:

> I'm trying to add subtome to a new site we're putting together and there's one page where I'd like to have a list of 'subscribe' buttons that each allow the user to subscribe to a different feed.
> 
> e.g. 
> 
> |-----------------------------------------|
> |   Subscribe to news feed    |  http://example.com/news-feed.xml
> |-----------------------------------------|
> 
> |-----------------------------------------|
> |      Subscribe to  offers      |  http://offers.example.com/offers.xml
> |-----------------------------------------| 

Quick, clear response:

> Yes, it is perfeclt possible to have 2 different feeds (or more!) with different SubToMe buttons.
> 
> The 'trick' is to load the SubToMe iframe with differents params for each feeds.
> So, for example, for the news feed you'll load:
> https://subtome.com/#/subscribe?resource=<encoded url of the page of the resource, the news page for example>&feeds=http%3A%2F%2Fexample.com%2Fnews-feed.xml
> 
> And for the offers's page:
> https://subtome.com/#/subscribe?resource=<encoded url of the page of the resource, the offers page for example>&feeds=http%3A%2F%2Fexample.com%2Foffers.xml
> 
> Also, make sure the iframe has the following CSS properties:
> display:block; 
> 
> position:fixed; 
> top:0px; 
> left:0px; 
> width:100%; 
> height:100%; 
> border:0px; 
> background: transparent; 
> z-index: 2147483647'
> 
> The rest is completely up to you in terms of customization. Feel free to check the "default" load.js https://www.subtome.com/load.js to see exactly how we load the iframe 'by default' (when there is only a single feed!).

Yeah, thing is I'm a lazy developer and really couldn't be bothered to do all of this. Ok, the fact that I'm making a PR contradicts that point, but I wanted it to be easier to achieve what I was after.

So what this pull request does is add an additional file very similar to `load.js` but isn't a self-calling anonymous function.  We load the `load-custom.js` script from subtome.com in the normal way and then call `subToMe()` in my `onclick` event.  This works just the same as the existing `load.js` script (i.e. it will scrape the page for RSS feeds). 

Now if I pass an argument, that argument becomes the feed URL so I can point my subscribe links at different feeds instead.

You may think this is unnecessary, but I thought I'd make the PR just in case you thought it was a useful addition. In the project I made this for I've included the script locally to get the same functionality.  The advantage of it being in the **subtome** repo is that it gets the love of upgrades and bug fixes that everyone benefits from :)

Thanks, Lloyd. 
